### PR TITLE
Implemented fix by Richard: exception led to Success(Failure(..))

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/*.sc
 target/
 pom.xml.tag
 pom.xml.releaseBackup

--- a/src/main/scala/nl/knaw/dans/easy/fsrdb/FsRdbUpdater.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fsrdb/FsRdbUpdater.scala
@@ -169,18 +169,15 @@ object FsRdbUpdater {
   }
 
   private def updateDB(conn: Connection, items: List[Item])(implicit s: Settings): Try[Unit] = Try {
-    try {
-      items.foreach {
-        case folder: FolderItem => updateOrInsertFolder(conn, folder).get
-        case file: FileItem => updateOrInsertFile(conn, file).get
-      }
-      conn.commit();
+    items.foreach {
+      case folder: FolderItem => updateOrInsertFolder(conn, folder).get
+      case file: FileItem => updateOrInsertFile(conn, file).get
     }
-    catch {
-      case t: Throwable =>
-        conn.rollback()
-        Failure(t)
-    }
+    conn.commit();
+  } recoverWith {
+    case t: Throwable =>
+      conn.rollback()
+      Failure(t)
   }
 
   private def updateOrInsertFolder(conn: Connection, folder: FolderItem): Try[Unit] = {


### PR DESCRIPTION
A Java-style try-catch construct that returned a Failure in case the catch
was executed was passed to Try.apply. Try.apply will wrap the result of the
function that is passed into it as an argument in a Success. Only if the
function that is passed into Try.apply throws an exception will Try.apply
convert it to a Failure. See the source code of Try.apply, which is simple
enough.

The net result was that a Failure was wrapped in a Success, so it was not
noticed and the program failed silently.