### PR TITLE
Add a new PR template in .github/

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+fixes EASY-
+
+#### When applied it will
+* 
+* 
+* 
+
+#### Where should the reviewer @DANS-KNAW/easy start?
+
+#### How should this be manually tested?
+
+#### related pull requests on github
+repo                       | PR
+-------------------------- | -----------------
+easy-                      | [PR#](PRlink) 


### PR DESCRIPTION
fixes EASY-1068

####When applied it will
* Add a new PR template in .github

####Where should the reviewer @DANS-KNAW/easy start?

####How should this be manually tested?
after this has been merged, a new PR should start with the content of the template file in the PR description