### PR TITLE
Scala lib collectResults refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.11</artifactId>
         </dependency>
+        <dependency>
+            <groupId>nl.knaw.dans.lib</groupId>
+            <artifactId>dans-scala-lib</artifactId>
+            <version>1.x-SNAPSHOT</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.32</version>
+        <version>1.33</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-update-fs-rdb</artifactId>
@@ -79,7 +79,6 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib</artifactId>
-            <version>1.x-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/src/main/scala/nl/knaw/dans/easy/fsrdb/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fsrdb/package.scala
@@ -19,8 +19,6 @@ import java.io.File
 
 import com.yourmediashelf.fedora.client.FedoraCredentials
 
-import scala.util.{Success, Failure, Try}
-
 package object fsrdb {
   object Settings {
     /** Backward compatible for EasyIngestFlow */
@@ -61,14 +59,4 @@ package object fsrdb {
                       visibleTo: String,
                       accessibleTo: String,
                       sha1Checksum: String) extends Item(pid, parentSid, datasetSid, path)
-
-  class CompositeException(throwables: List[Throwable]) extends RuntimeException(throwables.foldLeft("")((msg, t) => s"$msg\n${t.getMessage}"))
-
-  implicit class ListTryExtensions[T](xs: List[Try[T]]) {
-    def sequence: Try[List[T]] =
-      if (xs.exists(_.isFailure))
-        Failure(new CompositeException(xs.collect { case Failure(e) => e }))
-      else
-        Success(xs.map(_.get))
-  }
 }


### PR DESCRIPTION
@DANS-KNAW/easy 
- adds *dans-scala-lib* as a dependency
- refactors the use of `sequence` or `collectResults` to use the library implementation