### PR TITLE
EASY-1945: upgrade dependencies

### DIFF
--- a/command/pom.xml
+++ b/command/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath />
     </parent>
 

--- a/command/pom.xml
+++ b/command/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath />
     </parent>
 

--- a/command/pom.xml
+++ b/command/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
         <relativePath />
     </parent>
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-project</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
         <relativePath />
     </parent>
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-project</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath />
     </parent>
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-project</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath />
     </parent>
 

--- a/lib/src/main/scala/nl.knaw.dans.easy.fsrdb/FsRdbUpdater.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.fsrdb/FsRdbUpdater.scala
@@ -168,7 +168,7 @@ object FsRdbUpdater extends DebugEnhancedLogging {
 
     response.code match {
       case 200 => Try {
-        response.body.lines.toList.drop(1)
+        response.body.linesIterator.toList.drop(1)
           .map(_.replace("info:fedora/", ""))
           .filter(pid => namespaces.exists(pid.startsWith))
       }

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.0.0-M1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -49,7 +48,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
                     <autoVersionSubmodules>true</autoVersionSubmodules>


### PR DESCRIPTION
Fixes EASY-1945

#### When applied it will
* upgrade parent POM version
* remove self-contained dependency version tags
* change `lines.toList` to `linesIterator.toList` due to https://github.com/scala/bug/issues/11125

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink)